### PR TITLE
Remove torch version number

### DIFF
--- a/applications/DeepSpeed-Chat/requirements.txt
+++ b/applications/DeepSpeed-Chat/requirements.txt
@@ -2,6 +2,6 @@ datasets==2.11.0
 sentencepiece==0.1.97
 protobuf==4.22.1
 accelerate==0.18.0
-torch==1.12.1
+torch
 git+https://github.com/microsoft/deepspeed.git
 git+https://github.com/huggingface/transformers


### PR DESCRIPTION
The torch version installed by deepspeed is the latest stable 2.0, but this requirements file fixes it to an old version. The execution of `pip install requirements` will uninstall the new PyTorch and install the old version, which causes runtime errors.